### PR TITLE
Add autoupdate

### DIFF
--- a/systemd/nostream-migrations.container
+++ b/systemd/nostream-migrations.container
@@ -6,6 +6,7 @@ WantedBy=nostream-pod.service
 Image=ghcr.io/danvergara/nostream_migrations:latest
 ContainerName=nosream-migrations
 Network=nostream.network
+AutoUpdate=registry
 Environment=DB_PASSWORD=nostr_ts_relay
 Environment=DB_NAME=nostr_ts_relay
 Environment=DB_USER=nostr_ts_relay

--- a/systemd/nostream-pod.kube
+++ b/systemd/nostream-pod.kube
@@ -13,3 +13,5 @@ Network=nostream.network
 PublishPort=8008:8008
 # Use the nostream config map in the same directory
 ConfigMap=nostream-configmap.yml
+# podman run equivalent: --label “io.containers.autoupdate=registry”
+AutoUpdate=registry


### PR DESCRIPTION
## Changes

This PR add `AutoUpdate=registry` to the database migrations container file and the nostream pod kube file, which is equal to add `--label io.containers.autoupdate=registry` to the `$ podman run/create` command. This enables the [auto-update feature](https://www.redhat.com/sysadmin/podman-auto-updates-rollbacks) that makes sure to pull the newest image available on the registry every 24 hours. If Podman fails to spin up the new container, will perform a rollback to the previous image version.